### PR TITLE
Implement TSDF for hand-eye calibration verification, points extraction, and format conversion scripts

### DIFF
--- a/convert_to_plain_format.py
+++ b/convert_to_plain_format.py
@@ -1,0 +1,116 @@
+import numpy as np
+import os
+import argparse
+from PIL import Image
+
+# Constants that probably don't change
+# TODO(roger): these constants are copied in several files and should be unified and documented
+DEPTH_SCALING_FACTOR    = 1000.0
+DEPTH_CUTOFF            = 1.0
+VOXEL_SIZE              =0.005
+
+# From handeye.ipynb
+cam_to_gripper_rot = np.array([[-7.77766820e-02, -9.44073658e-01, -3.20430518e-01],
+ [ 9.96970509e-01, -7.34019190e-02, -2.57286360e-02],
+ [ 7.69512542e-04, -3.21460864e-01,  9.46922553e-01]])
+
+cam_to_gripper_trans = np.array([[ 0.10598264], [-0.02439176], [-0.08322135]])
+
+cam_to_gripper_pose = np.eye(4)
+cam_to_gripper_pose[:3, :3] = cam_to_gripper_rot
+cam_to_gripper_pose[:3, 3] = cam_to_gripper_trans.squeeze()
+
+def gather_single_sequence_data(base_dir):
+    assert os.path.exists(base_dir), f"Path {base_dir} does not exist"
+    intrinsic_mat = np.load(os.path.join(base_dir, 'camera_intrinsics.npz'))
+
+    fx, fy = intrinsic_mat['fx'], intrinsic_mat['fy']
+    ppx, ppy = intrinsic_mat['ppx'], intrinsic_mat['ppy']
+
+    depth_image_path = os.path.join(base_dir, 'camera_depth')
+    assert os.path.exists(depth_image_path), f"Path {depth_image_path} does not exist"
+    depth_image_path_list = sorted([os.path.join(depth_image_path, f) for f in os.listdir(depth_image_path) if f.endswith('.npy')])
+    depth_image_list = [np.load(f) for f in depth_image_path_list]
+
+    rgb_image_path = os.path.join(base_dir, 'camera_rgb')
+    assert os.path.exists(rgb_image_path), f"Path {rgb_image_path} does not exist"
+    rgb_image_path_list = sorted([os.path.join(rgb_image_path, f) for f in os.listdir(rgb_image_path) if f.endswith('.png')])
+    rgb_image_list = [np.array(Image.open(f).convert('RGB')) for f in rgb_image_path_list]
+
+    assert len(depth_image_list) == len(rgb_image_list)
+    assert depth_image_list[0].shape == rgb_image_list[0].shape[:2]
+
+    pose_path = os.path.join(base_dir, 'poses')
+    assert os.path.exists(pose_path), f"Path {pose_path} does not exist"
+    pose_path_list = sorted([os.path.join(pose_path, f) for f in os.listdir(pose_path) if f.endswith('.npy')])
+    pose_list = [np.load(f) @ cam_to_gripper_pose for f in pose_path_list]
+
+    return {
+        'fx': fx,
+        'fy': fy,
+        'ppx': ppx,
+        'ppy': ppy,
+        'depth_image_list': depth_image_list,
+        'rgb_image_list': rgb_image_list,
+        'pose_list': pose_list
+    }
+
+def main(src_dir, dst_dir):
+    dataset_dict = None
+
+    for seq_name in os.listdir(src_dir):
+        seq_dir = os.path.join(src_dir, seq_name)
+        if not os.path.isdir(seq_dir):
+            continue
+        print(f'Processing sequence {seq_name}')
+        seq_data = gather_single_sequence_data(seq_dir)
+
+        if dataset_dict is None:
+            dataset_dict = seq_data
+        else:
+            assert np.isclose(dataset_dict['fx'], seq_data['fx'])
+            assert np.isclose(dataset_dict['fy'], seq_data['fy'])
+            assert np.isclose(dataset_dict['ppx'], seq_data['ppx'])
+            assert np.isclose(dataset_dict['ppy'], seq_data['ppy'])
+            assert dataset_dict['depth_image_list'][0].shape == seq_data['depth_image_list'][0].shape
+            assert dataset_dict['rgb_image_list'][0].shape == seq_data['rgb_image_list'][0].shape
+            dataset_dict['depth_image_list'] += seq_data['depth_image_list']
+            dataset_dict['rgb_image_list'] += seq_data['rgb_image_list']
+            dataset_dict['pose_list'] += seq_data['pose_list']
+    
+    os.makedirs(dst_dir, exist_ok=True)
+    color_dir = os.path.join(dst_dir, 'color')
+    depth_dir = os.path.join(dst_dir, 'depth')
+    pose_dir = os.path.join(dst_dir, 'pose')
+    os.makedirs(color_dir, exist_ok=True)
+    os.makedirs(depth_dir, exist_ok=True)
+    os.makedirs(pose_dir, exist_ok=True)
+
+    # Save intrinsics
+    intrinsics_mat = np.array([
+        [dataset_dict['fx'], 0, dataset_dict['ppx']],
+        [0, dataset_dict['fy'], dataset_dict['ppy']],
+        [0, 0, 1]
+    ])
+
+    np.savetxt(os.path.join(dst_dir, 'intrinsics.txt'), intrinsics_mat)
+
+    # Save color images
+    for i, img in enumerate(dataset_dict['rgb_image_list']):
+        Image.fromarray(img).save(os.path.join(color_dir, f'{i:06d}.png'))
+    
+    # Save depth images
+    for i, img in enumerate(dataset_dict['depth_image_list']):
+        img = img.astype(np.uint16)
+        Image.fromarray(img).save(os.path.join(depth_dir, f'{i:06d}.png'))
+    
+    # Save poses as txt
+    for i, pose in enumerate(dataset_dict['pose_list']):
+        np.savetxt(os.path.join(pose_dir, f'{i:06d}.txt'), pose)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Convert dataset to plain format')
+    parser.add_argument('--src_dir', type=str, required=True, help='Source directory containing the dataset')
+    parser.add_argument('--dst_dir', type=str, required=True, help='Destination directory to save the converted dataset')
+    args = parser.parse_args()
+    main(args.src_dir, args.dst_dir)

--- a/tsdf.ipynb
+++ b/tsdf.ipynb
@@ -21,8 +21,9 @@
    "outputs": [],
    "source": [
     "# Constants that probably don't change\n",
-    "DEPTH_SCALING_FACTOR = 1000.0\n",
-    "DEPTH_CUTOFF = 1.0\n",
+    "DEPTH_SCALING_FACTOR    = 1000.0\n",
+    "DEPTH_CUTOFF            = 1.0\n",
+    "VOXEL_SIZE              =0.005\n",
     "\n",
     "# From handeye.ipynb\n",
     "cam_to_gripper_rot = np.array([[-7.77766820e-02, -9.44073658e-01, -3.20430518e-01],\n",
@@ -116,8 +117,8 @@
    "outputs": [],
    "source": [
     "volume = o3d.pipelines.integration.ScalableTSDFVolume(\n",
-    "    voxel_length=0.01,\n",
-    "    sdf_trunc=3 * 0.01,\n",
+    "    voxel_length=VOXEL_SIZE,\n",
+    "    sdf_trunc=3 * VOXEL_SIZE,\n",
     "    color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8\n",
     ")\n",
     "\n",
@@ -150,6 +151,15 @@
    "outputs": [],
    "source": [
     "mesh = volume.extract_triangle_mesh()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh.vertices"
    ]
   },
   {

--- a/tsdf.ipynb
+++ b/tsdf.ipynb
@@ -20,107 +20,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "base_dir = './data/poses/center_pose1'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.path.exists(base_dir)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "intrinsic_mat = np.load(os.path.join(base_dir, 'camera_intrinsics.npz'))\n",
-    "intrinsic_mat"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fx, fy = intrinsic_mat['fx'], intrinsic_mat['fy']\n",
-    "ppx, ppy = intrinsic_mat['ppx'], intrinsic_mat['ppy']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(fx, fy, ppx, ppy)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "depth_image_path = os.path.join(base_dir, 'camera_depth')\n",
-    "depth_image_path_list = sorted([os.path.join(depth_image_path, f) for f in os.listdir(depth_image_path) if f.endswith('.npy')])\n",
-    "depth_image_list = [np.load(f) for f in depth_image_path_list]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rgb_image_path = os.path.join(base_dir, 'camera_rgb')\n",
-    "rgb_image_path_list = sorted([os.path.join(rgb_image_path, f) for f in os.listdir(rgb_image_path) if f.endswith('.png')])\n",
-    "rgb_image_list = [np.array(Image.open(f).convert('RGB')) for f in rgb_image_path_list]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "assert len(depth_image_list) == len(rgb_image_list)\n",
-    "assert depth_image_list[0].shape == rgb_image_list[0].shape[:2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.imshow(rgb_image_list[0])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# Constants that probably don't change\n",
+    "DEPTH_SCALING_FACTOR = 1000.0\n",
+    "DEPTH_CUTOFF = 1.0\n",
+    "\n",
+    "# From handeye.ipynb\n",
     "cam_to_gripper_rot = np.array([[-7.77766820e-02, -9.44073658e-01, -3.20430518e-01],\n",
     " [ 9.96970509e-01, -7.34019190e-02, -2.57286360e-02],\n",
     " [ 7.69512542e-04, -3.21460864e-01,  9.46922553e-01]])\n",
     "\n",
-    "cam_to_gripper_trans = np.array([[ 0.10598264], [-0.02439176], [-0.08322135]])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "cam_to_gripper_trans = np.array([[ 0.10598264], [-0.02439176], [-0.08322135]])\n",
+    "\n",
     "cam_to_gripper_pose = np.eye(4)\n",
     "cam_to_gripper_pose[:3, :3] = cam_to_gripper_rot\n",
     "cam_to_gripper_pose[:3, 3] = cam_to_gripper_trans.squeeze()"
@@ -132,7 +42,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cam_to_gripper_pose"
+    "def gather_single_sequence_data(base_dir):\n",
+    "    assert os.path.exists(base_dir), f\"Path {base_dir} does not exist\"\n",
+    "    intrinsic_mat = np.load(os.path.join(base_dir, 'camera_intrinsics.npz'))\n",
+    "\n",
+    "    fx, fy = intrinsic_mat['fx'], intrinsic_mat['fy']\n",
+    "    ppx, ppy = intrinsic_mat['ppx'], intrinsic_mat['ppy']\n",
+    "\n",
+    "    depth_image_path = os.path.join(base_dir, 'camera_depth')\n",
+    "    assert os.path.exists(depth_image_path), f\"Path {depth_image_path} does not exist\"\n",
+    "    depth_image_path_list = sorted([os.path.join(depth_image_path, f) for f in os.listdir(depth_image_path) if f.endswith('.npy')])\n",
+    "    depth_image_list = [np.load(f) for f in depth_image_path_list]\n",
+    "\n",
+    "    rgb_image_path = os.path.join(base_dir, 'camera_rgb')\n",
+    "    assert os.path.exists(rgb_image_path), f\"Path {rgb_image_path} does not exist\"\n",
+    "    rgb_image_path_list = sorted([os.path.join(rgb_image_path, f) for f in os.listdir(rgb_image_path) if f.endswith('.png')])\n",
+    "    rgb_image_list = [np.array(Image.open(f).convert('RGB')) for f in rgb_image_path_list]\n",
+    "\n",
+    "    assert len(depth_image_list) == len(rgb_image_list)\n",
+    "    assert depth_image_list[0].shape == rgb_image_list[0].shape[:2]\n",
+    "\n",
+    "    pose_path = os.path.join(base_dir, 'poses')\n",
+    "    assert os.path.exists(pose_path), f\"Path {pose_path} does not exist\"\n",
+    "    pose_path_list = sorted([os.path.join(pose_path, f) for f in os.listdir(pose_path) if f.endswith('.npy')])\n",
+    "    pose_list = [np.load(f) @ cam_to_gripper_pose for f in pose_path_list]\n",
+    "\n",
+    "    return {\n",
+    "        'fx': fx,\n",
+    "        'fy': fy,\n",
+    "        'ppx': ppx,\n",
+    "        'ppy': ppy,\n",
+    "        'depth_image_list': depth_image_list,\n",
+    "        'rgb_image_list': rgb_image_list,\n",
+    "        'pose_list': pose_list\n",
+    "    }"
    ]
   },
   {
@@ -141,9 +84,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pose_path = os.path.join(base_dir, 'poses')\n",
-    "pose_path_list = sorted([os.path.join(pose_path, f) for f in os.listdir(pose_path) if f.endswith('.npy')])\n",
-    "pose_list = [np.load(f) @ cam_to_gripper_pose for f in pose_path_list]"
+    "dataset_dir = './data/objects_to_catch/'\n",
+    "\n",
+    "dataset_dict = None\n",
+    "\n",
+    "for seq_name in os.listdir(dataset_dir):\n",
+    "    seq_dir = os.path.join(dataset_dir, seq_name)\n",
+    "    if not os.path.isdir(seq_dir):\n",
+    "        continue\n",
+    "    print(f'Processing sequence {seq_name}')\n",
+    "    seq_data = gather_single_sequence_data(seq_dir)\n",
+    "\n",
+    "    if dataset_dict is None:\n",
+    "        dataset_dict = seq_data\n",
+    "    else:\n",
+    "        assert np.isclose(dataset_dict['fx'], seq_data['fx'])\n",
+    "        assert np.isclose(dataset_dict['fy'], seq_data['fy'])\n",
+    "        assert np.isclose(dataset_dict['ppx'], seq_data['ppx'])\n",
+    "        assert np.isclose(dataset_dict['ppy'], seq_data['ppy'])\n",
+    "        assert dataset_dict['depth_image_list'][0].shape == seq_data['depth_image_list'][0].shape\n",
+    "        assert dataset_dict['rgb_image_list'][0].shape == seq_data['rgb_image_list'][0].shape\n",
+    "        dataset_dict['depth_image_list'] += seq_data['depth_image_list']\n",
+    "        dataset_dict['rgb_image_list'] += seq_data['rgb_image_list']\n",
+    "        dataset_dict['pose_list'] += seq_data['pose_list']"
    ]
   },
   {
@@ -158,16 +121,15 @@
     "    color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8\n",
     ")\n",
     "\n",
-    "H, W = depth_image_list[0].shape\n",
-    "fx, fy, cx, cy = intrinsic_mat['fx'], intrinsic_mat['fy'], intrinsic_mat['ppx'], intrinsic_mat['ppy']\n",
+    "H, W = dataset_dict['depth_image_list'][0].shape\n",
     "\n",
-    "for idx in trange(len(depth_image_list)):\n",
-    "    pose = pose_list[idx]\n",
+    "for idx in trange(len(dataset_dict['depth_image_list'])):\n",
+    "    pose = dataset_dict['pose_list'][idx]\n",
     "\n",
-    "    rgb = rgb_image_list[idx]\n",
+    "    rgb = dataset_dict['rgb_image_list'][idx]\n",
     "    rgb = np.ascontiguousarray(rgb)\n",
-    "    depth = depth_image_list[idx] / 1000.0\n",
-    "    depth[depth > 5.0] = 0.0 # remove invalid depth\n",
+    "    depth = dataset_dict['depth_image_list'][idx] / DEPTH_SCALING_FACTOR\n",
+    "    depth[depth > DEPTH_CUTOFF] = 0.0 # remove invalid depth\n",
     "    depth = np.ascontiguousarray(depth.astype(np.float32))\n",
     "\n",
     "    rgb = o3d.geometry.Image(rgb)\n",
@@ -175,7 +137,7 @@
     "\n",
     "    rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(\n",
     "        rgb, depth, depth_scale=1.0, depth_trunc=4.0, convert_rgb_to_intensity=False)\n",
-    "    intrinsic = o3d.camera.PinholeCameraIntrinsic(width=W, height=H, fx=fx, fy=fy, cx=cx, cy=cy)\n",
+    "    intrinsic = o3d.camera.PinholeCameraIntrinsic(width=W, height=H, fx=dataset_dict['fx'], fy=dataset_dict['fy'], cx=dataset_dict['ppx'], cy=dataset_dict['ppy'])\n",
     "    extrinsic = np.linalg.inv(pose)\n",
     "    # extrinsic = pose\n",
     "    volume.integrate(rgbd, intrinsic, extrinsic)"
@@ -206,10 +168,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mesh = volume.extract_triangle_mesh()\n",
-    "mesh_path = os.path.join('/tmp/tmp.ply')\n",
+    "mesh_path = os.path.join('./extracted.ply')\n",
     "o3d.io.write_triangle_mesh(mesh_path, mesh)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tsdf.ipynb
+++ b/tsdf.ipynb
@@ -178,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mesh_path = os.path.join('./extracted.ply')\n",
+    "mesh_path = './extracted.ply'\n",
     "o3d.io.write_triangle_mesh(mesh_path, mesh)"
    ]
   },
@@ -187,7 +187,20 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "sampled_pcd = mesh.sample_points_uniformly(number_of_points=100000)\n",
+    "o3d.visualization.draw_geometries([sampled_pcd])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pcd_path = './sampled_pcd.ply'\n",
+    "o3d.io.write_point_cloud(pcd_path, sampled_pcd)"
+   ]
   }
  ],
  "metadata": {

--- a/tsdf.ipynb
+++ b/tsdf.ipynb
@@ -1,0 +1,236 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import open3d as o3d\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import matplotlib.pyplot as plt\n",
+    "from tqdm import tqdm, trange\n",
+    "from PIL import Image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_dir = './data/poses/center_pose1'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.path.exists(base_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "intrinsic_mat = np.load(os.path.join(base_dir, 'camera_intrinsics.npz'))\n",
+    "intrinsic_mat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fx, fy = intrinsic_mat['fx'], intrinsic_mat['fy']\n",
+    "ppx, ppy = intrinsic_mat['ppx'], intrinsic_mat['ppy']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(fx, fy, ppx, ppy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "depth_image_path = os.path.join(base_dir, 'camera_depth')\n",
+    "depth_image_path_list = sorted([os.path.join(depth_image_path, f) for f in os.listdir(depth_image_path) if f.endswith('.npy')])\n",
+    "depth_image_list = [np.load(f) for f in depth_image_path_list]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rgb_image_path = os.path.join(base_dir, 'camera_rgb')\n",
+    "rgb_image_path_list = sorted([os.path.join(rgb_image_path, f) for f in os.listdir(rgb_image_path) if f.endswith('.png')])\n",
+    "rgb_image_list = [np.array(Image.open(f).convert('RGB')) for f in rgb_image_path_list]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert len(depth_image_list) == len(rgb_image_list)\n",
+    "assert depth_image_list[0].shape == rgb_image_list[0].shape[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(rgb_image_list[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cam_to_gripper_rot = np.array([[-7.77766820e-02, -9.44073658e-01, -3.20430518e-01],\n",
+    " [ 9.96970509e-01, -7.34019190e-02, -2.57286360e-02],\n",
+    " [ 7.69512542e-04, -3.21460864e-01,  9.46922553e-01]])\n",
+    "\n",
+    "cam_to_gripper_trans = np.array([[ 0.10598264], [-0.02439176], [-0.08322135]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cam_to_gripper_pose = np.eye(4)\n",
+    "cam_to_gripper_pose[:3, :3] = cam_to_gripper_rot\n",
+    "cam_to_gripper_pose[:3, 3] = cam_to_gripper_trans.squeeze()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cam_to_gripper_pose"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pose_path = os.path.join(base_dir, 'poses')\n",
+    "pose_path_list = sorted([os.path.join(pose_path, f) for f in os.listdir(pose_path) if f.endswith('.npy')])\n",
+    "pose_list = [np.load(f) @ cam_to_gripper_pose for f in pose_path_list]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "volume = o3d.pipelines.integration.ScalableTSDFVolume(\n",
+    "    voxel_length=0.01,\n",
+    "    sdf_trunc=3 * 0.01,\n",
+    "    color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8\n",
+    ")\n",
+    "\n",
+    "H, W = depth_image_list[0].shape\n",
+    "fx, fy, cx, cy = intrinsic_mat['fx'], intrinsic_mat['fy'], intrinsic_mat['ppx'], intrinsic_mat['ppy']\n",
+    "\n",
+    "for idx in trange(len(depth_image_list)):\n",
+    "    pose = pose_list[idx]\n",
+    "\n",
+    "    rgb = rgb_image_list[idx]\n",
+    "    rgb = np.ascontiguousarray(rgb)\n",
+    "    depth = depth_image_list[idx] / 1000.0\n",
+    "    depth[depth > 5.0] = 0.0 # remove invalid depth\n",
+    "    depth = np.ascontiguousarray(depth.astype(np.float32))\n",
+    "\n",
+    "    rgb = o3d.geometry.Image(rgb)\n",
+    "    depth = o3d.geometry.Image(depth)\n",
+    "\n",
+    "    rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(\n",
+    "        rgb, depth, depth_scale=1.0, depth_trunc=4.0, convert_rgb_to_intensity=False)\n",
+    "    intrinsic = o3d.camera.PinholeCameraIntrinsic(width=W, height=H, fx=fx, fy=fy, cx=cx, cy=cy)\n",
+    "    extrinsic = np.linalg.inv(pose)\n",
+    "    # extrinsic = pose\n",
+    "    volume.integrate(rgbd, intrinsic, extrinsic)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh = volume.extract_triangle_mesh()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# visualize mesh\n",
+    "o3d.visualization.draw_geometries([mesh])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh = volume.extract_triangle_mesh()\n",
+    "mesh_path = os.path.join('/tmp/tmp.ply')\n",
+    "o3d.io.write_triangle_mesh(mesh_path, mesh)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "scene-nerf-viz",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- Roughly tested to construct a reasonably good TSDF from intrinsics/extrinsics calibrated using Mazeyu's scripts
- Implement routines for extracting mesh/point clouds from TSDF
- Implement a format conversion script to convert from Mazeyu's per-sequence format to Roger's plain 3D OpenCV format